### PR TITLE
Use full git commit hash in specmatic-beta devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "autoprefixer": "^10.4.19",
         "postcss": "^8.4.39",
         "specmatic": "^2.11.2",
-        "specmatic-beta": "github:znsio/specmatic-node-beta#72bba12",
+        "specmatic-beta": "github:znsio/specmatic-node-beta#72bba12594377f28ec40ec721e1a1630fa2c22cd",
         "tailwindcss": "^3.4.3"
       }
     },
@@ -16380,7 +16380,9 @@
     "node_modules/specmatic-beta": {
       "version": "1.0.0",
       "resolved": "git+ssh://git@github.com/znsio/specmatic-node-beta.git#72bba12594377f28ec40ec721e1a1630fa2c22cd",
-      "dev": true
+      "integrity": "sha512-y8+FAklE2XMnasbxflLeyl5HNnXRfaksoUuvHmAJHm5j05sjWWLdk1TLZzU4qQF2lTmUEcBgaNKeot0zBgFNSw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/specmatic/node_modules/cliui": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.39",
     "specmatic": "^2.11.2",
-    "specmatic-beta": "github:znsio/specmatic-node-beta#72bba12",
+    "specmatic-beta": "github:znsio/specmatic-node-beta#72bba12594377f28ec40ec721e1a1630fa2c22cd",
     "tailwindcss": "^3.4.3"
   }
 }


### PR DESCRIPTION
Use full git commit hash in github link mentioned for specmatic-beta in package.json/devDependencies. `npm install` seems to understand the full git commit hash, and upgrades the package if the commit hash in package.json changes. It didn't seem to recognize the short hash.