### PR TITLE
Removed the special command for installing specmatic-node-commercial from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ Install the node packages for this project.
 npm install
 ```
 
-```shell
-npm install git+https://github.com/znsio/specmatic-node-commercial.git#87b71a590ee2d1d272e90dc99f7f646fc92291aa
-```
-Note - Pick up the version (#72bba12) from package.json
-
 ## Running automated UI Component tests with Specmatic GraphQL Stub
 
 ```shell


### PR DESCRIPTION
We don't need a special command to install `specmatic-node-commercial` as we are now using the full commit hash of the relevant commit on `specmatic-node-commercial` in package.json. Now, `npm` seamlessly updates `specmatic-node-commercial` when the commit has changes.